### PR TITLE
Move each metric to its own goroutine/loop

### DIFF
--- a/exporter/main.go
+++ b/exporter/main.go
@@ -32,10 +32,10 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		go newMetricsExporter(
+		newMetricsExporter(
 			sdk.NewAPIClient(address, token, &opts),
 			time.Duration(scrapeInterval),
-		).run(ctx)
+		).start(ctx)
 	}
 
 	var server libHTTP.Server


### PR DESCRIPTION
This PR moves each metric function to its own goroutine and for loop, which allows for exporting metrics at a higher frequency if needed.