### PR TITLE
ci: do not publish edge images on merge to main

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -154,9 +154,6 @@ const publishChartJob = (event: Event, version: string) => {
   })
 }
 
-// Run the entire suite of tests WITHOUT publishing anything initially. If
-// EVERYTHING passes AND this was a push (merge, presumably) to the main branch,
-// then run jobs to publish "edge" images.
 events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
   await new SerialGroup(
     new ConcurrentGroup( // Basic tests
@@ -169,13 +166,6 @@ events.on("brigade.sh/github", "ci:pipeline_requested", async event => {
       buildGrafanaJob(event)
     )
   ).run()
-  if (event.worker?.git?.ref == "main") {
-    // Push "edge" images
-    await new ConcurrentGroup(
-      pushExporterJob(event),
-      pushGrafanaJob(event)
-    ).run()
-  }
 })
 
 // This event indicates a specific job is to be re-run.


### PR DESCRIPTION
For quite some time, we've published images tagged with a git sha and "edge" upon every merge to main -- the result being that we use up a _lot_ of storage on DockerHub. Most of these images are never pulled/used, as they _don't_ represent stable, officially released software. As I prepare for the _possibility_ of moving off of DockerHub for various reasons, I'm becoming more conscious of not using up registry space so indiscriminately.

This PR stops us from publishing "edge" images after each merge.