### PR TITLE
upgrade to brigadecore/go-tools:v0.8.0 -- includes go 1.18

### DIFF
--- a/.brigade/brigade.ts
+++ b/.brigade/brigade.ts
@@ -1,6 +1,6 @@
 import { events, Event, Job, ConcurrentGroup, SerialGroup, Container } from "@brigadecore/brigadier"
 
-const goImg = "brigadecore/go-tools:v0.7.0"
+const goImg = "brigadecore/go-tools:v0.8.0"
 const dindImg = "docker:20.10.9-dind"
 const dockerClientImg = "brigadecore/docker-tools:v0.2.0"
 const helmImg = "brigadecore/helm-tools:v0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty --match=NeVeRmAtC
 
 ifneq ($(SKIP_DOCKER),true)
 	PROJECT_ROOT := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
-	GO_DEV_IMAGE := brigadecore/go-tools:v0.7.0
+	GO_DEV_IMAGE := brigadecore/go-tools:v0.8.0
 
 	GO_DOCKER_CMD := docker run \
 		-it \

--- a/exporter/Dockerfile
+++ b/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.7.0 as builder
+FROM --platform=$BUILDPLATFORM brigadecore/go-tools:v0.8.0 as builder
 
 ARG VERSION
 ARG COMMIT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/brigadecore/brigade-metrics
 
-go 1.17
+go 1.18
 
 require (
 	github.com/brigadecore/brigade-foundations v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -204,7 +204,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/golangci.yaml
+++ b/golangci.yaml
@@ -6,7 +6,7 @@ run:
 linters:
   disable-all: true
   enable:
-  - bodyclose
+  # - bodyclose # Not yet working with Go 1.18
   - depguard
   # - dupl
   - errcheck
@@ -25,8 +25,8 @@ linters:
   - prealloc
   - revive
   - unconvert
-  - unparam
-  - unused
+  # - unparam # Not yet working with Go 1.18
+  # - unused # Not yet working with Go 1.18
 
 # all available settings for all linters
 linters-settings:


### PR DESCRIPTION
Fixes #73 