### PR TITLE
Dockerfile: cache go mods in their own layer

### DIFF
--- a/exporter/Dockerfile
+++ b/exporter/Dockerfile
@@ -7,9 +7,10 @@ ARG TARGETARCH
 ENV CGO_ENABLED=0
 
 WORKDIR /src
-COPY exporter/ exporter/
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN go mod download
+COPY exporter/ exporter/
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
   -o bin/exporter \


### PR DESCRIPTION
This PR caches resolved dependencies in their own layer to improve build time when built repeatedly -- i.e. during dev.