### PR TITLE
devx: use ctlptl for setting up and tearing down dev clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,22 @@ publish-chart:
 # Targets to facilitate hacking on Brigade Prometheus.                         #
 ################################################################################
 
+.PHONY: hack-kind-up
+hack-kind-up:
+	ctlptl apply -f hack/kind/cluster.yaml
+	HELM_EXPERIMENTAL_OCI=1 helm upgrade brigade \
+		oci://ghcr.io/brigadecore/brigade \
+		--version v2.3.1 \
+		--install \
+		--create-namespace \
+		--namespace brigade \
+		--wait \
+		--timeout 300s
+
+.PHONY: hack-kind-down
+hack-kind-down:
+	ctlptl delete -f hack/kind/cluster.yaml
+
 .PHONY: hack-build-images
 hack-build-images: hack-build-exporter hack-pull-grafana
 

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ publish-chart:
 	'
 
 ################################################################################
-# Targets to facilitate hacking on Brigade Metrics.                            #
+# Targets to facilitate hacking on this component                              #
 ################################################################################
 
 .PHONY: hack-kind-up

--- a/hack/kind/cluster.yaml
+++ b/hack/kind/cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: ctlptl.dev/v1alpha1
+kind: Cluster
+name: kind-brigade-metrics-dev-cluster
+product: kind
+registry: brigade-dev-registry


### PR DESCRIPTION
Follow-up to #81 

This adds new make targets for starting and stopping a kind cluster using ctlptl.

`make hack-kind-up` will _also_ pre-install Brigade with no-frills, so if you're just working on metrics, this gets you moving really fast.

#81 should be merged first.